### PR TITLE
Update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-prometheus"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Trillium handler for Prometheus metrics scrapes"
 repository = "https://github.com/divviup/trillium-prometheus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ repository = "https://github.com/divviup/trillium-prometheus"
 license = "MPL-2.0"
 
 [dependencies]
-prometheus = { version = "0.13.3", default-features = false }
-tracing = { version = "0.1.37", default-features = false }
-trillium = "0.2.8"
-trillium-router = "0.3.5"
+prometheus = { version = "0.13.4", default-features = false }
+tracing = { version = "0.1.40", default-features = false }
+trillium = "0.2.20"
+trillium-router = "0.4.1"
 
 [dev-dependencies]
-trillium-smol = "0.2.1"
-trillium-testing = { version = "0.4.2", features = ["smol"] }
+trillium-smol = "0.4.2"
+trillium-testing = { version = "0.7.0", features = ["smol"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub fn text_format_handler(registry: Registry) -> Router {
             let encoder = TextEncoder::new();
             match encoder.encode(&registry.gather(), &mut buffer) {
                 Ok(()) => conn
-                    .with_header(
+                    .with_response_header(
                         KnownHeaderName::ContentType,
                         encoder.format_type().to_owned(),
                     )


### PR DESCRIPTION
This updates all dependencies, fixes a deprecation warning, enables Dependabot, and prepares for a new release. This is a breaking release, since we expose `trillium_router::Router` via a return type of a public function, and that crate went from 0.3 to 0.4.